### PR TITLE
Fall back to SERVER_NAME if HTTP_HOST is not set

### DIFF
--- a/lib/Plack/App/FakeModPerl1.pm
+++ b/lib/Plack/App/FakeModPerl1.pm
@@ -104,7 +104,7 @@ sub parsed_uri {
     return URI::URL->new(
           $self->{env}{'psgi.url_scheme'}
         . q{://}
-        . $self->{env}{HTTP_HOST}
+        . ($self->{env}{HTTP_HOST} || $self->{env}{SERVER_NAME} || '')
         . $self->{env}{REQUEST_URI}
     );
 }


### PR DESCRIPTION
The Host: header is optional in HTTP/1.0, so fall back to the server
name if not supplied. If neither is supplied, fall back to the empty
string, to avoid undef warnings.
