### PR TITLE
Replace NoTabsTests with Test::NoTabs

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -33,7 +33,7 @@ web = http://github.com/chiselwright/%s/issues
 
 [Test::Kwalitee]
 
-[NoTabsTests]
+[Test::NoTabs]
 
 [PkgDist]
 


### PR DESCRIPTION
The `Dist::Zilla` plugin `NoTabsTests` is deprecated in favour of
`Test::NoTabs`.