### PR TITLE
Add missing ABSTRACT statements from packages

### DIFF
--- a/lib/Plack/App/FakeApache1.pm
+++ b/lib/Plack/App/FakeApache1.pm
@@ -1,5 +1,5 @@
 package Plack::App::FakeApache1;
-# ABSTRACT: Plack::App::FakeApache1 needs a more meaningful abstract
+# ABSTRACT: Perl distro to aid in mod_perl1->PSGI migration
 use strict;
 use warnings;
 

--- a/lib/Plack/App/FakeApache1/Constants.pm
+++ b/lib/Plack/App/FakeApache1/Constants.pm
@@ -1,4 +1,5 @@
 package Plack::App::FakeApache1::Constants;
+# ABSTRACT: Define Apache1 constants
 use strict;
 use warnings;
 

--- a/lib/Plack/App/FakeApache1/Handler.pm
+++ b/lib/Plack/App/FakeApache1/Handler.pm
@@ -1,4 +1,5 @@
 package Plack::App::FakeApache1::Handler;
+# ABSTRACT: Mimic Apache's handler
 use strict;
 use warnings;
 

--- a/lib/Plack/App/FakeApache1/Request.pm
+++ b/lib/Plack/App/FakeApache1/Request.pm
@@ -1,4 +1,5 @@
 package Plack::App::FakeApache1::Request;
+# ABSTRACT: Mimic Apache1 requests
 use Moose;
 
 use HTTP::Status qw(:is :constants);

--- a/lib/Plack/App/FakeModPerl1.pm
+++ b/lib/Plack/App/FakeModPerl1.pm
@@ -1,4 +1,5 @@
 package Plack::App::FakeModPerl1;
+# ABSTRACT: Mimic Apache's mod_perl1
 use 5.10.1;
 use Moose;
 

--- a/lib/Plack/App/FakeModPerl1/Dispatcher.pm
+++ b/lib/Plack/App/FakeModPerl1/Dispatcher.pm
@@ -1,4 +1,5 @@
 package Plack::App::FakeModPerl1::Dispatcher;
+# ABSTRACT: Mimic Apache mod_perl1's dispatcher
 use 5.10.1;
 use Moose;
 

--- a/lib/Plack/App/FakeModPerl1/Server.pm
+++ b/lib/Plack/App/FakeModPerl1/Server.pm
@@ -1,4 +1,5 @@
 package Plack::App::FakeModPerl1::Server;
+# ABSTRACT: Mimic Apache mod_perl1's server
 use strict;
 use warnings;
 use 5.10.1;


### PR DESCRIPTION
The main ABSTRACT now matches the project description as noted on GitHub.
The remaining packages have had ABSTRACT statements added since these
statements are required by Dist::Zilla.