### PR TITLE
Add Travis-CI configuration file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,27 @@
+sudo: false
+
+language: perl
+
+perl:
+    - "5.20"
+    - "5.18"
+    - "5.16"
+    - "5.14"
+    - "5.12"
+    - "5.10"
+
+install:
+    - cpanm Dist::Zilla
+    - dzil authordeps --missing | cpanm -n
+    - dzil listdeps --missing | cpanm -n
+
+script:
+    # work around an issue with the Git::CommitBuild Dist::Zilla plugin,
+    # which requires the git user to be configured on the Travis infrastructure
+    - git config --global user.email "fakeapache1@example.com"
+    - git config --global user.name "Plack App FakeApache1"
+    # install an implicit dependency of the PodCoverageTests plugin
+    - cpanm -n Pod::Coverage::TrustPod
+    # to be implemented once the --author and --release tests pass
+    #- dzil test --author --release
+    - dzil test --noauthor


### PR DESCRIPTION
The [Travis-CI](https://travis-ci.org) continous integration service allows
open source projects to check their software for free.  This commit adds the
relevant configuration file so that Plack::App::FakeApache1 will be tested
automatically on pushes to the GitHub repository.

The current setup includes a workaround for how the Git::CommitBuild
Dist::Zilla plugin behaves on the Travis infrastructure.  The plugin tries
to create a branch, which it can't do since the git user.name and user.email
configuration options aren't set.  It is likely that as soon as Travis
upgrades their infrastructure to use git 2.x that this issue will go away
(on other test machines this problem didn't occur even though user.name and
user.email weren't set, however they used git 2.x.

Assuming the current pod-coverage test failures can be fixed, then the
`--noauthor` option can be removed from the call to `dzil test` and
eventually the `--release` option to `dzil test` can be added.