### PR TITLE
Purge trailing whitespace in source code

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -5,7 +5,7 @@ author           = Chisel <chisel@chizography.net>
 license          = Perl_5
 copyright_holder = Chisel Wright
 copyright_year   = 2011
- 
+
 [@Basic]
 
 ; Always have this earlier in the list

--- a/lib/Plack/App/FakeApache1.pm
+++ b/lib/Plack/App/FakeApache1.pm
@@ -38,10 +38,10 @@ sub call {
         }
     }
 
-    my $result = $handler->( $fake_req ); 
-    
+    my $result = $handler->( $fake_req );
+
     if ( $result != OK ) {
-        $fake_req->status( $result );    
+        $fake_req->status( $result );
     }
 
     return $fake_req->finalize;

--- a/lib/Plack/App/FakeApache1/Handler.pm
+++ b/lib/Plack/App/FakeApache1/Handler.pm
@@ -72,7 +72,7 @@ sub call_app {
 }
 
 # Plack methods
-sub finalize { 
+sub finalize {
     my $self     = shift;
     my $response = $self->plack_response;
 

--- a/lib/Plack/App/FakeApache1/Request.pm
+++ b/lib/Plack/App/FakeApache1/Request.pm
@@ -90,7 +90,7 @@ sub _build__subprocess_env { return Moose::APR::Table->new; }
 sub _build_dispatcher      { return Plack::App::FakeModPerl1::Dispatcher->new; }
 
 # Plack methods
-sub finalize { 
+sub finalize {
     my $self     = shift;
     my $response = $self->plack_response;
 

--- a/t/10.fakeapache1.t
+++ b/t/10.fakeapache1.t
@@ -12,7 +12,7 @@ can_ok($pafa1,
     /
 );
 
-my $faked_apache1 = Plack::App::FakeApache1->new( 
+my $faked_apache1 = Plack::App::FakeApache1->new(
     handler    => "Plack::App::FakeApache1::Handler",
     dir_config => {
         psgi_app        => './01-app/testapp.psgi',

--- a/t/10.plack.app.fakemodperl1.t
+++ b/t/10.plack.app.fakemodperl1.t
@@ -86,7 +86,7 @@ while (my $dispatch_data = shift @dispatches) {
         $expected_data->{handles},
     );
     subtest $subtest_name => sub {
-        ok( 
+        ok(
             defined $expected_data,
             'we have expected data for the current dispatch'
         );

--- a/t/50-app/00.fakeapache1.t
+++ b/t/50-app/00.fakeapache1.t
@@ -10,7 +10,7 @@ use Plack::App::FakeApache1;
 
 use FindBin::libs;
 
-my $faked_apache1 = Plack::App::FakeApache1->new( 
+my $faked_apache1 = Plack::App::FakeApache1->new(
     handler    => "Plack::App::FakeApache1::Handler",
     dir_config => {
         psgi_app        => $FindBin::Bin . '/testapp.psgi',


### PR DESCRIPTION
Trailing whitespace is something which some coding styles specify that should be removed (e.g. the [Linux Kernel Coding Style](https://www.kernel.org/doc/Documentation/CodingStyle)). Others see this as being purely superfluous.  This PR is submitted in the hope that it is helpful, however if you don't see the need for these changes, I have no problem with it being closed unmerged.  The PR is split into several commit so that the diffs aren't so large and so they can be cherry-picked should this be necessary.