### PR TITLE
Add missing strictures to fakeapache test

### DIFF
--- a/t/10.fakeapache1.t
+++ b/t/10.fakeapache1.t
@@ -1,4 +1,6 @@
 #!perl
+use strict;
+use warnings;
 use Test::More;
 use Plack::App::FakeApache1;
 


### PR DESCRIPTION
Although the test was OK, using strictures is still a good idea.