### PR TITLE
Remove perl shebang line in test scripts

### DIFF
--- a/t/10.fakeapache1.t
+++ b/t/10.fakeapache1.t
@@ -1,6 +1,6 @@
-#!perl
 use strict;
 use warnings;
+
 use Test::More;
 use Plack::App::FakeApache1;
 

--- a/t/10.plack.app.fakemodperl1.t
+++ b/t/10.plack.app.fakemodperl1.t
@@ -1,4 +1,3 @@
-#!perl
 use strict;
 use warnings;
 

--- a/t/50-app/00.fakeapache1.t
+++ b/t/50-app/00.fakeapache1.t
@@ -1,4 +1,3 @@
-#!perl
 use strict;
 use warnings;
 


### PR DESCRIPTION
The test scripts aren't executable, and they should be run either through
`perl` or as part of a `dzil test` run, hence it isn't necessary to use a
shebang line.