### PR TITLE
Remove locale dependence in parsed_apache_config test

### DIFF
--- a/t/10.plack.app.fakemodperl1.t
+++ b/t/10.plack.app.fakemodperl1.t
@@ -39,7 +39,7 @@ can_ok($pafmp1d,
 # but we won't get far without specifying anything useful
 throws_ok {
     $parsed_config = $pafmp1d->parsed_apache_config;
-} qr{cannot stat '/etc/myapp/apache_locations.conf': No such file or directory},
+} qr{cannot stat '/etc/myapp/apache_locations.conf':},
     'died with call to parsed_apache_config()';
 
 # now build one that has an apache config that exists


### PR DESCRIPTION
This corrects the problem raised in GitHub issue #5.  By not relying on the
locale-based error output in the test, one can then still check that the
test dies as expected, and with the expected error message, however still
allow the tests to run correctly on systems with a non-English locale.