### PR TITLE
Increase error severity in dispatcher's call handler

### DIFF
--- a/lib/Plack/App/FakeModPerl1/Dispatcher.pm
+++ b/lib/Plack/App/FakeModPerl1/Dispatcher.pm
@@ -214,7 +214,7 @@ sub _call_handler {
         }
     }
     catch ($e) {
-        Carp::cluck( "$module->handler(): $e" );
+        Carp::confess( "$module->handler(): $e" );
         # if we error we override the status of everything up to this point!
         return HTTP_INTERNAL_SERVER_ERROR;
     }


### PR DESCRIPTION
As per the comment in GitHub issue #4, it was recommended to increase the
error severity to FATAL rather than WARN.  This uses `confess` as mentioned
in the ticket, however I'm unsure if this is sufficient to completely
address the bug.